### PR TITLE
Fixes Backend CORs

### DIFF
--- a/backend/api/router/router.go
+++ b/backend/api/router/router.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/labstack/gommon/log"
@@ -13,6 +15,11 @@ func New() *echo.Echo {
 	e.Pre(middleware.RemoveTrailingSlash())
 	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
 		Format: "method=${method}, uri=${uri}, status=${status}\n",
+	}))
+
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins: []string{"*"},
+		AllowMethods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete},
 	}))
 
 	// Middleware to handle JSON requests


### PR DESCRIPTION
Reported issue when trying to directly call backend from browser javascript resulted in a CORs error from the server. CORs config added to echo middleware should now allow the backend to be directly hit via the frontend.